### PR TITLE
Add runtime paths to OpenFOAM libraries.

### DIFF
--- a/etc/bashrc
+++ b/etc/bashrc
@@ -44,7 +44,7 @@ export WM_PROJECT_VERSION=dev
 #
 [ "$BASH" -o "$ZSH_NAME" ] && \
 export FOAM_INST_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/../.. && pwd -P) || \
-export FOAM_INST_DIR=$HOME/$WM_PROJECT
+export FOAM_INST_DIR=$HOME/opt/enrico/vendor/openfoam/
 # export FOAM_INST_DIR=~$WM_PROJECT
 # export FOAM_INST_DIR=/opt/$WM_PROJECT
 # export FOAM_INST_DIR=/usr/local/$WM_PROJECT

--- a/wmake/rules/linux64Gcc/c
+++ b/wmake/rules/linux64Gcc/c
@@ -10,7 +10,7 @@ cFLAGS      = $(GFLAGS) $(cWARN) $(cOPT) $(cDBUG) $(LIB_HEADER_DIRS) -fPIC
 
 ctoo        = $(WM_SCHEDULER) $(cc) $(cFLAGS) -c $< -o $@
 
-LINK_LIBS   = $(cDBUG)
+LINK_LIBS   = $(cDBUG) -Wl,-rpath=$(FOAM_LIBBIN),-rpath=$(FOAM_LIBBIN)/mpi-system
 
-LINKLIBSO   = $(cc) -fuse-ld=bfd -shared
+LINKLIBSO   = $(cc) -fuse-ld=bfd -shared -Wl,-rpath=$(FOAM_LIBBIN),-rpath=$(FOAM_LIBBIN)/mpi-system
 LINKEXE     = $(cc) -fuse-ld=bfd -Xlinker --add-needed -Xlinker -z -Xlinker nodefs

--- a/wmake/rules/linux64Gcc/c++
+++ b/wmake/rules/linux64Gcc/c++
@@ -19,7 +19,7 @@ cxxtoo      = $(Ctoo)
 cctoo       = $(Ctoo)
 cpptoo      = $(Ctoo)
 
-LINK_LIBS   = $(c++DBUG)
+LINK_LIBS   = $(c++DBUG) -Wl,-rpath=$(FOAM_LIBBIN),-rpath=$(FOAM_LIBBIN)/mpi-system
 
-LINKLIBSO   = $(CC) $(c++FLAGS) -fuse-ld=bfd -shared -Xlinker --add-needed -Xlinker --no-as-needed
+LINKLIBSO   = $(CC) $(c++FLAGS) -fuse-ld=bfd -shared -Xlinker --add-needed -Xlinker --no-as-needed -Wl,-rpath=$(FOAM_LIBBIN),-rpath=$(FOAM_LIBBIN)/mpi-system
 LINKEXE     = $(CC) $(c++FLAGS) -fuse-ld=bfd -Xlinker --add-needed -Xlinker --no-as-needed


### PR DESCRIPTION
Adds runtime paths to the shared libraries built by OpenFOAM. This let's us avoid setting the `LD_LIBRARY_PATH` environment variable.